### PR TITLE
Fix: added the missing field in redteam template

### DIFF
--- a/charts/platform/templates/opensearch/templates.yaml
+++ b/charts/platform/templates/opensearch/templates.yaml
@@ -1330,6 +1330,8 @@ spec:
   name: red_teaming_template
   indexPatterns:
     - "red_teaming"
+  dataStream: {} 
+
   template:
     settings:
       number_of_shards: 1


### PR DESCRIPTION
- dataStream: {} was missing in CR but exist in json