### PR TITLE
Integrated OpenTelemetry with OpenSearch for log

### DIFF
--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -5,6 +5,13 @@ dependencies:
   name: platform-core
   repository: https://enkryptai.github.io/helm-charts
   version: 1.1.0
+
+- alias: otel
+  name: opentelemetry-collector
+  version: "0.138.1"
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  condition: otel.enabled
+
 description: Complete platform infrastructure stack
 name: platform-stack
 version: 1.1.26

--- a/charts/platform/templates/opensearch/ism-policy.yaml
+++ b/charts/platform/templates/opensearch/ism-policy.yaml
@@ -3,15 +3,16 @@ kind: OpenSearchISMPolicy
 metadata:
   name: rollbar-policy
   annotations:
-    "helm.sh/hook-weight": "18"
-    "helm.sh/hook": post-install
+    helm.sh/hook-weight: "18"
+    helm.sh/hook: "post-install,post-upgrade"
 spec:
   opensearchCluster:
-    name: {{ .Values.clustername }} 
+    name: {{ .Values.clustername }}
   description: "ISM policy equivalent to ES ILM"
-  defaultState: "hot"
+  defaultState: hot
   ismTemplate:
     indexPatterns:
+      - otel-*
       - admin
       - guardrails
       - ai-proxy
@@ -20,21 +21,30 @@ spec:
       - .ds-*
     priority: 999
   states:
-    - name: "hot"
+    - name: hot
       actions:
-      - rollover:
-          minIndexAge: "0d"
+        - rollover:
+            min_index_age: "1d"
+            min_size: "50gb"
+        - replica_count:
+            number_of_replicas: 1
       transitions:
         - stateName: warm
           conditions:
-            minIndexAge: 15d
+            minIndexAge: "15d"
+
     - name: warm
       actions:
-        - readOnly: {}
+        - read_only: {}
+        - force_merge:
+            max_num_segments: 1
+        - replica_count:
+            number_of_replicas: 0
       transitions:
         - stateName: delete
           conditions:
-            minIndexAge: 30d
+            minIndexAge: "{{ .Values.opensearch.ism.retentionDays }}d"
+
     - name: delete
       actions:
         - delete: {}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -44,7 +44,11 @@ opensearch:
       hash: ""
     kibana_read_only:
       hash: ""
-
+  ism:
+    # enabled: true
+    policyName: "otel-logs-lifecycle"
+    indexPattern: "otel-*"
+    retentionDays: 15
 platform-core:
   namespaces:
     - name: argo-events
@@ -304,3 +308,230 @@ platform-core:
         errored: 3
 externalSecret:
   enabled: false
+
+# ------------------------------------------------
+# OTEL CONFIG
+# -----------------------------------------------
+otel:
+  enabled: false
+  mode: daemonset
+  annotations: 
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "20"
+  ports:
+    otlp:
+      enabled: true
+      containerPort: 4317
+      hostPort: null
+
+    otlp-http:
+      enabled: true
+      containerPort: 4318
+      hostPort: null
+
+    jaeger-compact:
+      enabled: false
+
+    jaeger-grpc:
+      enabled: false
+
+    jaeger-thrift:
+      enabled: false
+
+    zipkin:
+      enabled: false
+  image:
+    repository: 188451452903.dkr.ecr.us-east-1.amazonaws.com/onprem/otel:0.141.0
+
+  clusterRole:
+    create: true
+    rules:
+    - apiGroups: [""]
+      resources: ["pods", "namespaces", "nodes"]
+      verbs: ["get", "list", "watch"]
+
+    - apiGroups: ["apps"]
+      resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
+      verbs: ["get", "list", "watch"]
+
+    - apiGroups: ["batch"]
+      resources: ["jobs", "cronjobs"]
+      verbs: ["get", "list", "watch"]
+
+  tolerations:
+  - key: "app"
+    operator: "Equal"
+    value: "redteaming"
+    effect: "NoSchedule"
+    
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 512Mi
+  
+  extraEnvs:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: OPENSEARCH_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-cred
+          key: username
+    - name: OPENSEARCH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-cred
+          key: password
+  
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      
+      filelog:
+        include: [/var/log/pods/*/*/*.log]
+        exclude: [/var/log/pods/*/otel-*/*.log]
+        start_at: beginning
+        include_file_path: true
+        operators:
+          - type: container
+            id: container-parser
+
+    processors:
+
+      batch:
+        timeout: 10s
+        send_batch_size: 256
+        send_batch_max_size: 512
+      
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 800
+      
+      resource:
+        attributes:
+          - key: deployment.environment
+            value: test
+            action: insert
+      
+      resourcedetection:
+        detectors: [env, system]
+        timeout: 5s
+      
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: NODE_NAME
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.pod.start_time
+            - k8s.pod.hostname
+            - k8s.pod.ip
+            - k8s.replicaset.uid
+            - k8s.replicaset.name
+            - k8s.deployment.uid
+            - k8s.daemonset.uid
+            - k8s.statefulset.uid
+            - k8s.cronjob.uid
+            - k8s.job.uid
+            - k8s.cluster.uid
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: connection
+    extensions:
+      health_check:
+        endpoint: ${env:POD_IP}:13133
+      basicauth/os:
+        client_auth:
+          username: ${env:OPENSEARCH_USERNAME}
+          password: ${env:OPENSEARCH_PASSWORD}
+
+    exporters:
+      # debug:
+      #   verbosity: basic
+      
+      opensearch:
+        http:
+          endpoint: https://enkryptai-opensearch-cluster:9200
+          auth:
+            authenticator: basicauth/os
+          # tls:
+          #   insecure_skip_verify: true
+          tls:
+            ca_file: /etc/opensearch/certs/ca.crt
+          max_idle_conns: 100
+          idle_conn_timeout: 90s
+        
+        logs_index: "otel-logs"
+        traces_index: "otel-traces"
+
+        sending_queue:
+          enabled: true
+          num_consumers: 5
+          queue_size: 1000
+        
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+        
+        timeout: 60s
+
+    service:
+      extensions: [health_check, basicauth/os]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, resourcedetection, k8sattributes, resource, batch]
+          exporters: [debug, opensearch]
+
+        logs:
+          receivers: [otlp, filelog]
+          processors: [memory_limiter, resourcedetection, k8sattributes, resource, batch]
+          exporters: [debug, opensearch]
+
+  extraVolumes:
+    - name: varlog
+      hostPath:
+        path: /var/log
+    - name: opensearch-ca
+      secret:
+        secretName: enkryptai-opensearch-ca
+        items:
+          - key: ca.crt
+            path: ca.crt
+
+  extraVolumeMounts:
+    - name: varlog
+      mountPath: /var/log
+      readOnly: true
+    - name: opensearch-ca
+      mountPath: /etc/opensearch/certs
+      readOnly: true


### PR DESCRIPTION
Integrated OpenTelemetry with OpenSearch for log ingestion. Configured a 15-day log retention period, and can be changed by `values.yaml`. Tested on the `eks-enkryptai-saas` cluster, working as expected.