### PR TITLE
fix: add nack and nats dependencies to enkryptai-stack

### DIFF
--- a/charts/enkryptai-stack/Chart.lock
+++ b/charts/enkryptai-stack/Chart.lock
@@ -1,4 +1,10 @@
 dependencies:
+- name: nats
+  repository: https://nats-io.github.io/k8s/helm/charts
+  version: 1.3.14
+- name: nack
+  repository: https://nats-io.github.io/k8s/helm/charts/
+  version: 0.29.2
 - name: openfga
   repository: https://openfga.github.io/helm-charts
   version: 0.2.26

--- a/charts/enkryptai-stack/Chart.yaml
+++ b/charts/enkryptai-stack/Chart.yaml
@@ -2,9 +2,21 @@ apiVersion: v2
 name: enkryptai-stack
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.20
-appVersion: "1.1.20"
+version: 1.1.21
+appVersion: "1.1.21"
 dependencies:
+  - name: nats
+    version: 1.3.14
+    alias: nats
+    repository: "https://nats-io.github.io/k8s/helm/charts"
+    condition: nats.enabled
+
+  - name: nack
+    version: 0.29.2
+    alias: nack
+    repository: "https://nats-io.github.io/k8s/helm/charts/"
+    condition: nack.enabled
+
   - name: openfga
     version: 0.2.26
     alias: openfga

--- a/charts/enkryptai-stack/values.yaml
+++ b/charts/enkryptai-stack/values.yaml
@@ -781,6 +781,31 @@ guardrails-model:
 
   affinity: {}
 
+################NATS NACK###########################
+nats:
+  enabled: true
+  image:
+    repository: nats
+    tag: 2.10.20-alpine
+  jetstream:
+    enabled: true
+    fileStore:
+      enabled: true
+      storageDirectory: /data
+
+nack:
+  enabled: true
+  jetstream:
+    enabled: true
+    image:
+      registry: "188451452903.dkr.ecr.us-east-1.amazonaws.com"
+      repository: "onprem/jetstream-controller"
+      tag: "0.19.1"
+    tls:
+      enabled: false
+  nats:
+    url: "nats://nats:4222"
+
 guardrails-multi-modal:
   enabled: false
   replicaCount: 1


### PR DESCRIPTION
## Summary
- Add `nats` and `nack` as dependencies in `Chart.yaml` so that when installing `enkryptai-stack`, nack gets created
- Add corresponding entries in `Chart.lock`
- Add nats and nack configuration in `values.yaml`

## Issue
The `enkryptai-stack` chart was missing nack as a dependency, causing it not to be installed.