### PR TITLE
Simplify check results condition in helm-check.yaml

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -82,9 +82,8 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.lint-and-test.result }}" != "success" ]] || \
-             [[ "${{ needs.template-validation.result }}" != "success" ]] || \
-             [[ "${{ needs.version-check.result }}" != "success" ]] || \
+          if [[ "${{ needs.template-validation.result }}" != "success" ]] || \
+             [[ "${{ needs.security-scan.result }}" != "success" ]] || \
              [[ "${{ needs.documentation-check.result }}" != "success" ]]; then
             echo "One or more required checks failed"
             exit 1


### PR DESCRIPTION
## Summary

Fix the Helm Chart CI workflow summary job to correctly reference the jobs defined in the workflow.

## Changes

* Removed references to non-existent `lint-and-test` and `version-check` jobs.
* Updated the summary job to validate:

  * `template-validation`
  * `security-scan`
  * `documentation-check`
* Fixed the summary check so it correctly reports the status of all required CI jobs.

## Impact

The CI summary job will now pass when all defined Helm CI checks succeed and fail only when one of the required checks fails.
